### PR TITLE
Whenever someone sends "pog" or "pogu" in chat, technobot will add the reaction.

### DIFF
--- a/src/main/java/com/technovision/technobot/listeners/ExtrasEventListener.java
+++ b/src/main/java/com/technovision/technobot/listeners/ExtrasEventListener.java
@@ -99,7 +99,8 @@ public class ExtrasEventListener extends ListenerAdapter {
                     .addField("Official Forge Discord", "https://discord.gg/UvedJ9m", false)
                     .build();
             event.getChannel().sendMessage(embed).queue();
-        }
+        } else if (msg.equalsIgnoreCase("pog")) event.getMessage().addReaction(":Pog:").queue();
+        else if (msg.equalsIgnoreCase("pogu")) event.getMessage().addReaction(":PogU:").queue();
 
         if (triggered) COOLDOWN_MAP.put(authorId, System.currentTimeMillis());
     }


### PR DESCRIPTION
This is only for consideration. If you decide that you don't want it in the bot, there's no need.